### PR TITLE
feat: add air to the project and remove entr

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,46 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./uploader-svc & go run ./deployer-service"
+  cmd = "go build -o ./uploader-svc ./uploader-service"
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = []
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,9 @@
 .PHONY: dev
 
 compose:
-	@docker-compose up -d || docker compose up -d
-
-deployer:
-	@make watch & go run ./deployer-service
+	@docker-compose up -d || (echo "Compose failed, stopping execution"; exit 1)
 
 uploader:
-	@make watch & go run ./uploader-service
+	@air
 
-watch:
-	@find . -name "*.go" | entr -r sh -c 'echo "Restarted"'
-
-dev:
-	@make compose & make deployer & make uploader
+dev: compose uploader


### PR DESCRIPTION
Closes #14 

- Switch from entr to air
- Update Makefile to use `air`
- Exit programs when `make compose` fails since it's mandatory for the program to work


The is a lot of configuration to play around, I just let the default ones that come with `air init` and excluded `terraform` folder.

I feel that `air` is much more focused on single binaries projects, I did some workaround on [bin](https://github.com/NicolasLopes7/shipthing/pull/15/files#diff-5045264cfa788dee4cbdc88799a69eb96f2c51cc8434e7dc9719ba7afa6f5217R7) to fit the need of running both binaries.